### PR TITLE
Events - Work on T3.x and T4

### DIFF
--- a/examples/mtp-test/mtp-test.ino
+++ b/examples/mtp-test/mtp-test.ino
@@ -4,7 +4,11 @@
 #include "MTP.h"
 
 #define USE_SD  1         // SDFAT based SDIO and SPI
+#ifdef ARDUINO_TEENSY41
+#define USE_LFS_RAM 1     // T4.1 PSRAM (or RAM)
+#else
 #define USE_LFS_RAM 0     // T4.1 PSRAM (or RAM)
+#endif
 #define USE_LFS_QSPI 1    // T4.1 QSPI
 #define USE_LFS_PROGM 1   // T4.4 Progam Flash
 #define USE_LFS_SPI 1     // SPI Flash
@@ -57,7 +61,7 @@ SDClass sdx[nsd];
 //LittleFS classes
 #if USE_LFS_RAM==1
   const char *lfs_ram_str[]={"RAM1","RAM2"};     // edit to reflect your configuration
-  const int lfs_ram_size[] = {2'000'000,4'000'000}; // edit to reflect your configuration
+  const int lfs_ram_size[] = {200'000,4'000'000}; // edit to reflect your configuration
   const int nfs_ram = sizeof(lfs_ram_str)/sizeof(const char *);
 
   LittleFS_RAM ramfs[nfs_ram]; 
@@ -313,16 +317,26 @@ void loop()
       {
         Serial.println("Add Files");
         static int count=100;
+        uint32_t store = storage.getStoreID("RAM1");
         for(int ii=0; ii<10;ii++)
         { char filename[80];
           sprintf(filename,"/test_%d.txt",count++);
           Serial.println(filename);
           File file=ramfs[0].open(filename,FILE_WRITE_BEGIN);
             file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
+            file.println("This is a test line");
           file.close();
+          mtpd.send_addObjectEvent(store, filename);
         }
         // attempt to notify PC on added files (does not work yet)
-        uint32_t store = storage.getStoreID("RAM1");
         Serial.print("Store "); Serial.println(store);
         mtpd.send_StorageInfoChangedEvent(store);
       }
@@ -331,6 +345,7 @@ void loop()
       {
         Serial.println("Add Files");
         static int count=100;
+        uint32_t store = storage.getStoreID("sdio");
         for(int ii=0; ii<10;ii++)
         { char filename[80];
           sprintf(filename,"/test_%d.txt",count++);
@@ -338,9 +353,9 @@ void loop()
           File file=sdx[0].open(filename,FILE_WRITE_BEGIN);
             file.println("This is a test line");
           file.close();
+          mtpd.send_addObjectEvent(store, filename);
         }
         // attempt to notify PC on added files (does not work yet)
-        uint32_t store = storage.getStoreID("sdio");
         Serial.print("Store "); Serial.println(store);
         mtpd.send_StorageInfoChangedEvent(store);
       }

--- a/examples/mtp-test/mtp-test.ino
+++ b/examples/mtp-test/mtp-test.ino
@@ -216,7 +216,8 @@ void setup()
   #if defined(USB_MTPDISK_SERIAL) 
     while(!Serial); // comment if you do not want to wait for terminal
   #else
-    while(!Serial.available()); // comment if you do not want to wait for terminal (otherwise press any key to continue)
+    //while(!Serial.available()); // comment if you do not want to wait for terminal (otherwise press any key to continue)
+    while(!Serial.available() && millis() < 5000); // or third option to wait up to 5 seconds and then continue
   #endif
   Serial.println("MTP_test");
 
@@ -295,6 +296,17 @@ void loop()
     {
       Serial.println("Reset");
       mtpd.send_DeviceResetEvent();
+    }
+    if (ch=='d')
+    {
+      // first dump list of storages:
+      uint32_t fsCount = storage.getFSCount();
+      Serial.printf("\nDump Storage list(%u)\n", fsCount);
+      for (uint32_t ii = 0; ii < fsCount; ii++) {
+        Serial.printf("store:%u name:%s fs:%x\n", ii, storage.getStoreName(ii), (uint32_t)storage.getStoreFS(ii));
+      }
+      Serial.println("\nDump Index List");
+      storage.dumpIndexList();
     }
     #if USE_LFS_RAM==1
       if(ch=='a') 

--- a/examples/mtp-test/mtp-test.ino
+++ b/examples/mtp-test/mtp-test.ino
@@ -4,7 +4,7 @@
 #include "MTP.h"
 
 #define USE_SD  1         // SDFAT based SDIO and SPI
-#define USE_LFS_RAM 1     // T4.1 PSRAM (or RAM)
+#define USE_LFS_RAM 0     // T4.1 PSRAM (or RAM)
 #define USE_LFS_QSPI 1    // T4.1 QSPI
 #define USE_LFS_PROGM 1   // T4.4 Progam Flash
 #define USE_LFS_SPI 1     // SPI Flash
@@ -311,6 +311,24 @@ void loop()
         }
         // attempt to notify PC on added files (does not work yet)
         uint32_t store = storage.getStoreID("RAM1");
+        Serial.print("Store "); Serial.println(store);
+        mtpd.send_StorageInfoChangedEvent(store);
+      }
+    #elif USE_SD==1
+      if(ch=='a') 
+      {
+        Serial.println("Add Files");
+        static int count=100;
+        for(int ii=0; ii<10;ii++)
+        { char filename[80];
+          sprintf(filename,"/test_%d.txt",count++);
+          Serial.println(filename);
+          File file=sdx[0].open(filename,FILE_WRITE_BEGIN);
+            file.println("This is a test line");
+          file.close();
+        }
+        // attempt to notify PC on added files (does not work yet)
+        uint32_t store = storage.getStoreID("sdio");
         Serial.print("Store "); Serial.println(store);
         mtpd.send_StorageInfoChangedEvent(store);
       }

--- a/examples/mtp-test/mtp-test.ino
+++ b/examples/mtp-test/mtp-test.ino
@@ -316,11 +316,11 @@ void loop()
       if(ch=='a') 
       {
         Serial.println("Add Files");
-        static int count=100;
+      static int next_file_index_to_add=100;
         uint32_t store = storage.getStoreID("RAM1");
         for(int ii=0; ii<10;ii++)
         { char filename[80];
-          sprintf(filename,"/test_%d.txt",count++);
+          sprintf(filename,"/test_%d.txt",next_file_index_to_add++);
           Serial.println(filename);
           File file=ramfs[0].open(filename,FILE_WRITE_BEGIN);
             file.println("This is a test line");
@@ -340,20 +340,56 @@ void loop()
         Serial.print("Store "); Serial.println(store);
         mtpd.send_StorageInfoChangedEvent(store);
       }
+      if(ch=='x') 
+      {
+        Serial.println("Delete Files");
+        static int next_file_index_to_delete=100;
+        uint32_t store = storage.getStoreID("RAM1");
+        for(int ii=0; ii<10;ii++)
+        { char filename[80];
+          sprintf(filename,"/test_%d.txt",next_file_index_to_delete++);
+          Serial.println(filename);
+          if (ramfs[0].remove(filename))
+          {
+            mtpd.send_removeObjectEvent(store, filename);
+          }
+        }
+        // attempt to notify PC on added files (does not work yet)
+        Serial.print("Store "); Serial.println(store);
+        mtpd.send_StorageInfoChangedEvent(store);
+      }
     #elif USE_SD==1
       if(ch=='a') 
       {
         Serial.println("Add Files");
-        static int count=100;
+        static int next_file_index_to_add=100;
         uint32_t store = storage.getStoreID("sdio");
         for(int ii=0; ii<10;ii++)
         { char filename[80];
-          sprintf(filename,"/test_%d.txt",count++);
+          sprintf(filename,"/test_%d.txt",next_file_index_to_add++);
           Serial.println(filename);
           File file=sdx[0].open(filename,FILE_WRITE_BEGIN);
             file.println("This is a test line");
           file.close();
           mtpd.send_addObjectEvent(store, filename);
+        }
+        // attempt to notify PC on added files (does not work yet)
+        Serial.print("Store "); Serial.println(store);
+        mtpd.send_StorageInfoChangedEvent(store);
+      }
+      if(ch=='x') 
+      {
+        Serial.println("Delete Files");
+        static int next_file_index_to_delete=100;
+        uint32_t store = storage.getStoreID("sdio");
+        for(int ii=0; ii<10;ii++)
+        { char filename[80];
+          sprintf(filename,"/test_%d.txt",next_file_index_to_delete++);
+          Serial.println(filename);
+          if (sdx[0].remove(filename))
+          {
+            mtpd.send_removeObjectEvent(store, filename);
+          }
         }
         // attempt to notify PC on added files (does not work yet)
         Serial.print("Store "); Serial.println(store);

--- a/src/MTP.cpp
+++ b/src/MTP.cpp
@@ -1595,8 +1595,19 @@ const uint16_t supported_events[] =
       return true;
     }
     return false;
-
   }
+
+  bool MTPD::send_removeObjectEvent(uint32_t store, const char *pathname)
+  {
+    uint32_t handle = storage_->MapFileNameToIndex(store, pathname, false, nullptr);
+    printf("notifyFileRemoved: %x:%x maps to handle: %x\n", store, pathname, handle);
+    if (handle != 0xFFFFFFFFUL) {
+      send_removeObjectEvent(handle);
+      return true;
+    }
+    return false;
+  }
+
 
 
 

--- a/src/MTP.cpp
+++ b/src/MTP.cpp
@@ -210,7 +210,7 @@ const uint16_t supported_events[] =
 //    MTP_EVENT_REQUEST_OBJECT_TRANSFER           ,//0x4009
 //    MTP_EVENT_STORE_FULL                        ,//0x400A
     MTP_EVENT_DEVICE_RESET                      ,//0x400B
-//    MTP_EVENT_STORAGE_INFO_CHANGED              ,//0x400C
+    MTP_EVENT_STORAGE_INFO_CHANGED              ,//0x400C
 //    MTP_EVENT_CAPTURE_COMPLETE                  ,//0x400D
 //    MTP_EVENT_UNREPORTED_STATUS                 ,//0x400E
 //    MTP_EVENT_OBJECT_PROP_CHANGED               ,//0xC801
@@ -1583,6 +1583,22 @@ const uint16_t supported_events[] =
   { return send_Event(MTP_EVENT_OBJECT_ADDED, p1); }
   int MTPD::send_removeObjectEvent(uint32_t p1) 
   { return send_Event(MTP_EVENT_OBJECT_REMOVED, p1); }
+
+
+  bool MTPD::send_addObjectEvent(uint32_t store, const char *pathname)
+  {
+    bool node_added = false;
+    uint32_t handle = storage_->MapFileNameToIndex(store, pathname, true, &node_added);
+    printf("notifyFileCreated: %x:%x maps to handle: %x\n", store, pathname, handle);
+    if (handle != 0xFFFFFFFFUL) {
+      send_addObjectEvent(handle);
+      return true;
+    }
+    return false;
+
+  }
+
+
 
 #endif
 #endif

--- a/src/MTP.h
+++ b/src/MTP.h
@@ -162,6 +162,12 @@ public:
   int send_StorageInfoChangedEvent(uint32_t p1);
   int send_StorageRemovedEvent(uint32_t p1);
   int send_DeviceResetEvent(void);
+
+  // higer level version of sending events
+  // unclear if should pass in pfs or store? 
+  bool send_addObjectEvent(uint32_t store, const char *pathname);
+
+
 #endif
 };
 

--- a/src/MTP.h
+++ b/src/MTP.h
@@ -166,6 +166,7 @@ public:
   // higer level version of sending events
   // unclear if should pass in pfs or store? 
   bool send_addObjectEvent(uint32_t store, const char *pathname);
+  bool send_removeObjectEvent(uint32_t store, const char *pathname);
 
 
 #endif

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -132,6 +132,7 @@ public:
   virtual uint32_t copy(uint32_t handle, uint32_t newStorage, uint32_t newParent) = 0 ;
 
   virtual bool CopyFiles(uint32_t storage, uint32_t handle, uint32_t newHandle) = 0;
+  virtual uint32_t MapFileNameToIndex(uint32_t storage, const char *pathname,  bool addLastNode=false, bool *node_added=nullptr) = 0;
 };
 
   struct Record 
@@ -198,6 +199,7 @@ private:
   uint16_t ConstructFilename(int i, char* out, int len) ;
   void OpenFileByIndex(uint32_t i, uint32_t mode = FILE_READ) ;
   void printRecord(int h, Record *p);
+  void printRecordIncludeName(int h, Record *p);
 
   uint32_t get_FSCount(void) {return sd_getFSCount();}
   const char *get_FSName(uint32_t storage) { return sd_getFSName(storage);}
@@ -220,6 +222,7 @@ private:
 
   bool CopyFiles(uint32_t storage, uint32_t handle, uint32_t newHandle) override ;
   void ResetIndex() override ;
+  uint32_t MapFileNameToIndex(uint32_t storage, const char *pathname, bool addLastNode=false, bool *node_added=nullptr) override; 
 };
 
 #endif


### PR DESCRIPTION
Note: I added some additional debug code, not sure if you want or not.

But on the T3.x I changed the code over to allocate a transfer each time you send an event.  As I found that all of the other USB TX type code in the core3 appears to do this as I believe when you send a packet, when the send is completed that transfer object is returned to the free queue.  The code is also setup to allow up to some N TX packets to be pending (I have it set at 4).

I was thinking of also maybe trying to integrate my other code which does successfully send out the Add object, delete object, add directory type events, which works, although you still have to hit F5 to see them.

The issue is that I have additional code added in my version where I basically ask the storage to find the pathname and covert to the node number and then send the event.  Not sure how you want to do such stuff.

But it is in my fork/branch

I updated the test sketch that if you don't have RAM disk it will try to do the add files to SDIO SD... As not really enough memory on T3.6 for decent ram drive

Note: I have been testing it with my version of the changes to the MTP USB Descriptors for both T3.x and T4.x which I put in a PR to core: https://github.com/PaulStoffregen/cores/pull/532

Let me know what you think. 