### PR TITLE
Fix link error: `undefined reference to 'vtable for MTPStorageInterface'`

### DIFF
--- a/src/Storage.h
+++ b/src/Storage.h
@@ -107,7 +107,7 @@ public:
 
   virtual uint32_t Create(uint32_t storage, uint32_t parent, bool folder, const char* filename) = 0;
   virtual void read(uint32_t handle, uint32_t pos, char* buffer, uint32_t bytes) = 0;
-  virtual size_t write(const char* data, uint32_t size);
+  virtual size_t write(const char* data, uint32_t size) = 0;
   virtual void close() = 0;
   virtual bool DeleteObject(uint32_t object) = 0;
   virtual void CloseIndex() = 0;


### PR DESCRIPTION
Not sure why this popped up now, but I started getting a link error:

```
.pio/build/teensy41/src/main.cpp.o: In function `MTPStorageInterface::MTPStorageInterface()':
/home/mark/src/SOAR/SOAR-Code/SOAR-v2-Code/lib/MTP_t4/src/Storage.h:87: undefined reference to `vtable for MTPStorageInterface'
collect2: error: ld returned 1 exit status
*** [.pio/build/teensy41/firmware.elf] Error 1
```

Looking at https://stackoverflow.com/a/57504289 it looks like this parent class wasn't purely virtual, this one method wasn't defined purely virtually.