### PR TITLE
Remove extra data send which is already covered and random +4 bytes

### DIFF
--- a/src/MTP.cpp
+++ b/src/MTP.cpp
@@ -1042,10 +1042,6 @@ const uint16_t supported_events[] =
             len=0;
           }
         }
-        if(len>0)
-        { push_packet(tx_data_buffer,MTP_TX_SIZE);
-          len=0;
-        }
       }
       return size;
     }
@@ -1081,7 +1077,7 @@ const uint16_t supported_events[] =
       uint32_t dlen = FUN;                                \
       \
       MTPContainer header;                                   \
-      header.len = write_length_ + sizeof(MTPHeader)+4;      \
+      header.len = write_length_ + sizeof(MTPHeader);      \
       header.type = 2;                                    \
       header.op = CONTAINER->op;                          \
       header.transaction_id = CONTAINER->transaction_id;  \


### PR DESCRIPTION
Extra data left over from GetPartialObject is already caught and sent by code in TRANSMIT1 macro - this removed most of the garbage left at the end of small files for me, except for 4 extra bytes
Also removing random extra 4 bytes unless there is a reason for them - this removed all garbage from small file reads

Ref: https://github.com/WMXZ-EU/MTP_t4/issues/22